### PR TITLE
chore: cnv-3420 create pre-merge checklist for pr template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,14 @@ _Links to related JIRA tickets_
 * _Steps to test this change_
 * _Expected results_
 
+## :mag: Pre-Merge Checklist
+
+- [ ] _What would make this PR ready to merge?_
+- [ ] _Specify files/features/tests to check on if required_
+- [ ] _Other repositories that might be affected by these changes_
+- [ ] _Affected infrastructure resources, e.g. new environment variables_
+- [ ] _Necessary documentation updates_
+
 ## :speech_balloon: Further Comments
 
 * _Dependent PRs_


### PR DESCRIPTION
# :rocket: Description & Context

One action item that came up in our Sprint retrospective was adding a pre-merge checklist to pull requests, if needed. This would not only add context on the changes to reviewers, but would help authors to ensure their PR is ready for review and merging, from their side. The ultimate goal here is to ensure we don't miss the "little things" that can cause more work down the road after merging. 

I thought a good place to do this is in the Pull Request Template for our org.

[CNV-3420](https://puffer.atlassian.net/browse/CNV-3420)



[CNV-3420]: https://puffer.atlassian.net/browse/CNV-3420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ